### PR TITLE
Fix the Jekyll configuration

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,9 @@
-title: 'args: Type-safe argument parser for modern C++'
-remote_theme: 'pmarsceill/just-the-docs'
-color_scheme: 'dark'
+title: 'args'
+description: 'Type-safe argument parser for modern C++'
+author:
+  name: 'Dominik Lohmann'
+  mail: 'mail@dominiklohmann.de'
+  github_username: 'dominiklohmann'
+remote_theme: pmarsceill/just-the-docs
+color_scheme: dark
 search_enabled: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,6 @@
+---
+# You don't need to edit this file, it's empty on purpose.
+# Edit theme's home layout instead if you wanna make some changes
+# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+layout: home
+---


### PR DESCRIPTION
Experiments in a test repository have shown that the stub index.html is actually required. Additionally, this makes some amendments to the configuration.