### PR TITLE
Hide front matter in comments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Changelog
 permalink: /changelog
 ---
+-->
 
 # Changelog
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,9 @@
+<!--
 ---
-title: A type-safe argument parser for modern C++
+title: args
 permalink: /
 ---
+-->
 
 <p align="center">
     <h1 align="center">args</h1>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
-title: 'args'
-description: 'Type-safe argument parser for modern C++'
+title: 'A type-safe argument parser for modern C++.'
+description: 'args'
 author:
   name: 'Dominik Lohmann'
   mail: 'mail@dominiklohmann.de'

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Code of Conduct
 permalink: /code-of-conduct
 ---
+-->
 
 # Contributor Covenant Code of Conduct
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Contributing
 permalink: /contributing
 ---
+-->
 
 # Contributing
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Security Policy
 permalink: /security-policy
 ---
+-->
 
 # Security Policies and Procedures
 


### PR DESCRIPTION
I hope this hides the front matter on GitHub itself, while keeping its effect for the docs site. Let's see. Might have to revert if this does not work.