### PR TITLE
Rename project to wahl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ CTestTestfile.cmake
 DartConfiguration.tcl
 Makefile
 Testing/
-args_tests_*.cmake
+wahl_tests_*.cmake
 build*.ninja
 cmake_install.cmake
 doctestConfig.cmake
@@ -28,7 +28,7 @@ install_manifest.txt
 *.lib
 *.pdb
 *.so
-args_tests
+wahl_tests
 example.basic
 example.group
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
 project(
-  args
+  wahl
   DESCRIPTION "A type-safe argument parser for modern C++."
   VERSION 0.1
   LANGUAGES CXX)
@@ -19,18 +19,18 @@ file(GLOB_RECURSE sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
 
 # Create a library target.
-add_library(args ${sources})
+add_library(wahl ${sources})
 
-# Building args (and linking against it) requires C++17.
-target_compile_features(args PUBLIC cxx_std_17)
+# Building wahl (and linking against it) requires C++17.
+target_compile_features(wahl PUBLIC cxx_std_17)
 
 # Enforce standard compliance for MSVC.
-target_compile_options(args
+target_compile_options(wahl
   PUBLIC
     "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive>")
 
 # Set the include directory properly.
-target_include_directories(args
+target_include_directories(wahl
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,9 +14,9 @@ adheres to [Semantic Versioning][semver].
 
 ## [0.1.0] &ndash; 2021-02-20
 
-The initial release of `args`, a type-safe argument parser for modern C++.
+The initial release of `wahl`, a type-safe argument parser for modern C++.
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/dominiklohmann/args/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.1.0
+[Unreleased]: https://github.com/dominiklohmann/wahl/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/dominiklohmann/wahl/releases/tag/v0.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <h1 align="center">args</h1>
+    <h1 align="center">wahl</h1>
     <p align="center">A type-safe argument parser for modern C++.</p>
 </p>
 
@@ -20,9 +20,9 @@ struct hello {
   hello() : count(1) {}
 
   template <class F> void parse(F f) {
-    f(count, "--count", "-C", args::help("Number of greetings."));
-    f(name, "--name", "-N", args::help("The person to greet."),
-      args::required());
+    f(count, "--count", "-C", wahl::help("Number of greetings."));
+    f(name, "--name", "-N", wahl::help("The person to greet."),
+      wahl::required());
   }
 
   void run() {
@@ -32,7 +32,7 @@ struct hello {
 };
 
 int main(int argc, const char **argv) {
-  args::parse<hello>(argc, argv);
+  wahl::parse<hello>(argc, argv);
 }
 ```
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: 'args'
+title: 'wahl'
 description: 'Type-safe argument parser for modern C++'
 author:
   name: 'Dominik Lohmann'

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -4,13 +4,13 @@ cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
 project(example.basic)
 
-# Try to find an installed args, and if that's not available simply
+# Try to find an installed wahl, and if that's not available simply
 # include the subdirectory.
-find_package(args QUIET)
-if (NOT args_FOUND)
-  message(STATUS "args is not installed; using local library instead")
-  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "args")
+find_package(wahl QUIET)
+if (NOT wahl_FOUND)
+  message(STATUS "wahl is not installed; using local library instead")
+  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "wahl")
 endif ()
 
 add_executable(example.basic main.cpp)
-target_link_libraries(example.basic PRIVATE args::args)
+target_link_libraries(example.basic PRIVATE wahl::wahl)

--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 
 struct hello {
   static const char *help() {
@@ -13,9 +13,9 @@ struct hello {
   hello() : count(1) {}
 
   template <class F> void parse(F f) {
-    f(count, "--count", "-C", args::help("Number of greetings."));
-    f(name, "--name", "-N", args::help("The person to greet."),
-      args::required());
+    f(count, "--count", "-C", wahl::help("Number of greetings."));
+    f(name, "--name", "-N", wahl::help("The person to greet."),
+      wahl::required());
   }
 
   void run() {
@@ -24,4 +24,4 @@ struct hello {
   }
 };
 
-int main(int argc, const char **argv) { args::parse<hello>(argc, argv); }
+int main(int argc, const char **argv) { wahl::parse<hello>(argc, argv); }

--- a/examples/group/CMakeLists.txt
+++ b/examples/group/CMakeLists.txt
@@ -4,13 +4,13 @@ cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
 project(example.group)
 
-# Try to find an installed args, and if that's not available simply
+# Try to find an installed wahl, and if that's not available simply
 # include the subdirectory.
-find_package(args QUIET)
-if (NOT args_FOUND)
-  message(STATUS "args is not installed; using local library instead")
-  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "args")
+find_package(wahl QUIET)
+if (NOT wahl_FOUND)
+  message(STATUS "wahl is not installed; using local library instead")
+  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "wahl")
 endif ()
 
 add_executable(example.group main.cpp)
-target_link_libraries(example.group PRIVATE args::args)
+target_link_libraries(example.group PRIVATE wahl::wahl)

--- a/examples/group/main.cpp
+++ b/examples/group/main.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 
-struct cli : args::group<cli> {
+struct cli : wahl::group<cli> {
   static const char *help() {
     return "Command-line interface to manage a database";
   }
@@ -18,4 +18,4 @@ struct dropdb : cli::command<dropdb> {
   void run() { printf("Delete database\n"); }
 };
 
-int main(int argc, const char **argv) { args::parse<cli>(argc, argv); }
+int main(int argc, const char **argv) { wahl::parse<cli>(argc, argv); }

--- a/source/args.cpp
+++ b/source/args.cpp
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: BSL-1.0
-
-#include <args/args.hpp>
-#include <args/version.hpp>

--- a/source/wahl.cpp
+++ b/source/wahl.cpp
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: BSL-1.0
+
+#include <wahl/wahl.hpp>
+#include <wahl/version.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
-project(args_tests)
+project(wahl_tests)
 
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
-add_executable(args_tests ${sources})
+add_executable(wahl_tests ${sources})
 
 set(DOCTEST_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../third-party/doctest")
 add_subdirectory("${DOCTEST_SOURCE_DIR}" doctest)
@@ -15,15 +15,15 @@ add_subdirectory("${DOCTEST_SOURCE_DIR}" doctest)
 include(CTest)
 enable_testing()
 
-# Try to find an installed args, and if that's not available simply
+# Try to find an installed wahl, and if that's not available simply
 # include the subdirectory.
-find_package(args QUIET)
-if (NOT args_FOUND)
-  message(STATUS "args is not installed; using local library instead")
-  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/.." "args")
+find_package(wahl QUIET)
+if (NOT wahl_FOUND)
+  message(STATUS "wahl is not installed; using local library instead")
+  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/.." "wahl")
 endif ()
 
-target_link_libraries(args_tests PRIVATE args::args doctest::doctest)
+target_link_libraries(wahl_tests PRIVATE wahl::wahl doctest::doctest)
 
 include("${DOCTEST_SOURCE_DIR}/scripts/cmake/doctest.cmake")
-doctest_discover_tests(args_tests)
+doctest_discover_tests(wahl_tests)

--- a/tests/source/basic.cpp
+++ b/tests/source/basic.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 #include <doctest/doctest.h>
 
 struct single_value_cmd {
@@ -21,31 +21,31 @@ TEST_CASE("single value command") {
   REQUIRE_EQ(cmd.name, "");
 
   SUBCASE("log-options with space") {
-    args::parse(cmd, {"--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
   }
 
   SUBCASE("options may be omitted") {
-    args::parse(cmd, {"--count", "5"});
+    wahl::parse(cmd, {"--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "");
   }
 
   SUBCASE("long options with equal-sign") {
-    args::parse(cmd, {"--count=5", "--name=hello"});
+    wahl::parse(cmd, {"--count=5", "--name=hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
   }
 
   SUBCASE("short options with space") {
-    args::parse(cmd, {"-C", "5", "-N", "hello"});
+    wahl::parse(cmd, {"-C", "5", "-N", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
   }
 
   SUBCASE("short options without space") {
-    args::parse(cmd, {"-C5", "-Nhello"});
+    wahl::parse(cmd, {"-C5", "-Nhello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
   }
@@ -69,7 +69,7 @@ TEST_CASE("multi value command") {
   REQUIRE(cmd.names.empty());
 
   SUBCASE("repeated short options with spaces") {
-    args::parse(cmd, {"-N", "1", "-N", "2", "-N", "3", "--count", "5"});
+    wahl::parse(cmd, {"-N", "1", "-N", "2", "-N", "3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -78,7 +78,7 @@ TEST_CASE("multi value command") {
   }
 
   SUBCASE("single short option with spaces") {
-    args::parse(cmd, {"-N", "1", "2", "3", "--count", "5"});
+    wahl::parse(cmd, {"-N", "1", "2", "3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -87,7 +87,7 @@ TEST_CASE("multi value command") {
   }
 
   SUBCASE("repeated short options without spaces") {
-    args::parse(cmd, {"-N1", "-N2", "-N3", "--count", "5"});
+    wahl::parse(cmd, {"-N1", "-N2", "-N3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -96,7 +96,7 @@ TEST_CASE("multi value command") {
   }
 
   SUBCASE("repeated long options with spaces") {
-    args::parse(cmd,
+    wahl::parse(cmd,
                 {"--name", "1", "--name", "2", "--name", "3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
@@ -106,7 +106,7 @@ TEST_CASE("multi value command") {
   }
 
   SUBCASE("single long option with spaces") {
-    args::parse(cmd, {"--name", "1", "2", "3", "--count", "5"});
+    wahl::parse(cmd, {"--name", "1", "2", "3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -115,7 +115,7 @@ TEST_CASE("multi value command") {
   }
 
   SUBCASE("repeated long options with equal-sign") {
-    args::parse(cmd, {"--name=1", "--name=2", "--name=3", "--count", "5"});
+    wahl::parse(cmd, {"--name=1", "--name=2", "--name=3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -138,7 +138,7 @@ struct no_data_cmd {
 TEST_CASE("no value command") {
   auto cmd = no_data_cmd{};
   REQUIRE_EQ(cmd.name, "");
-  args::parse(cmd, {"--null", "--name=hello"});
+  wahl::parse(cmd, {"--null", "--name=hello"});
   CHECK_EQ(cmd.name, "hello");
 }
 
@@ -160,7 +160,7 @@ TEST_CASE("positional arguments command") {
   REQUIRE(cmd.names.empty());
 
   SUBCASE("positional arguments before option") {
-    args::parse(cmd, {"1", "2", "3", "--count", "5"});
+    wahl::parse(cmd, {"1", "2", "3", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -169,7 +169,7 @@ TEST_CASE("positional arguments command") {
   }
 
   SUBCASE("positional arguments after long option with space") {
-    args::parse(cmd, {"--count", "5", "1", "2", "3"});
+    wahl::parse(cmd, {"--count", "5", "1", "2", "3"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -178,7 +178,7 @@ TEST_CASE("positional arguments command") {
   }
 
   SUBCASE("positional arguments after long option with equal-sign") {
-    args::parse(cmd, {"--count=5", "1", "2", "3"});
+    wahl::parse(cmd, {"--count=5", "1", "2", "3"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -187,7 +187,7 @@ TEST_CASE("positional arguments command") {
   }
 
   SUBCASE("positional arguments after short option with space") {
-    args::parse(cmd, {"-C", "5", "1", "2", "3"});
+    wahl::parse(cmd, {"-C", "5", "1", "2", "3"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -196,7 +196,7 @@ TEST_CASE("positional arguments command") {
   }
 
   SUBCASE("positional arguments after short option without space") {
-    args::parse(cmd, {"-C5", "1", "2", "3"});
+    wahl::parse(cmd, {"-C5", "1", "2", "3"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.names.size(), 3);
     CHECK_EQ(cmd.names[0], "1");
@@ -213,6 +213,6 @@ struct no_arguments_cmd {
 TEST_CASE("no arguments command") {
   auto cmd = no_arguments_cmd{};
   REQUIRE_FALSE(cmd.check);
-  args::parse(cmd, {});
+  wahl::parse(cmd, {});
   CHECK(cmd.check);
 }

--- a/tests/source/callback.cpp
+++ b/tests/source/callback.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 #include <doctest/doctest.h>
 
 struct callback_cmd {
@@ -9,11 +9,11 @@ struct callback_cmd {
   std::string final_name = {};
 
   template <class F> void parse(F f) {
-    auto cb = [this](auto &&data, const auto &, const args::argument &) {
+    auto cb = [this](auto &&data, const auto &, const wahl::argument &) {
       for (size_t i = 0; i < data; ++i)
         final_name += name;
     };
-    f(count, "--count", "-C", args::callback(cb));
+    f(count, "--count", "-C", wahl::callback(cb));
     f(name, "--name", "-N");
   }
 
@@ -27,14 +27,14 @@ TEST_CASE("command callbacks") {
   REQUIRE_EQ(cmd.final_name, "");
 
   SUBCASE("callback with all options speciied") {
-    args::parse(cmd, {"--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_name, "hellohellohellohellohello");
   }
 
   SUBCASE("callbacks are evaluated for omitted options") {
-    args::parse(cmd, {"--name", "hello"});
+    wahl::parse(cmd, {"--name", "hello"});
     CHECK_EQ(cmd.count, 1);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_name, "hello");
@@ -47,11 +47,11 @@ struct lazy_callback_cmd {
   std::string final_name;
 
   template <class F> void parse(F f) {
-    auto cb = [this](auto &&data, const auto &, const args::argument &) {
+    auto cb = [this](auto &&data, const auto &, const wahl::argument &) {
       for (size_t i = 0; i < data; ++i)
         final_name += name;
     };
-    f(count, "--count", "-C", args::lazy_callback(cb));
+    f(count, "--count", "-C", wahl::lazy_callback(cb));
     f(name, "--name", "-N");
   }
 
@@ -65,14 +65,14 @@ TEST_CASE("lazy command callbacks") {
   REQUIRE_EQ(cmd.final_name, "");
 
   SUBCASE("lazy callback with all options speciied") {
-    args::parse(cmd, {"--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_name, "hellohellohellohellohello");
   }
 
   SUBCASE("lazy callbacks are not evaluated for omitted options") {
-    args::parse(cmd, {"--name", "hello"});
+    wahl::parse(cmd, {"--name", "hello"});
     CHECK_EQ(cmd.count, 1);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_name, "");
@@ -85,11 +85,11 @@ struct lazy_callback_null_cmd {
   std::string final_out = "";
 
   template <class F> void parse(F f) {
-    auto cb = [this](auto &&, const auto &, const args::argument &) {
+    auto cb = [this](auto &&, const auto &, const wahl::argument &) {
       for (size_t i = 0; i < count; ++i)
         final_out += name;
     };
-    f(nullptr, "--out", "-O", args::lazy_callback(cb));
+    f(nullptr, "--out", "-O", wahl::lazy_callback(cb));
     f(count, "--count", "-C");
     f(name, "--name", "-N");
   }
@@ -104,14 +104,14 @@ TEST_CASE("lazy command callbacks with null options") {
   REQUIRE_EQ(cmd.final_out, "");
 
   SUBCASE("lazy callback with all options speciied") {
-    args::parse(cmd, {"--out", "--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--out", "--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_out, "hellohellohellohellohello");
   }
 
   SUBCASE("lazy callbacks are not evaluated for omitted options") {
-    args::parse(cmd, {"--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_out, "");
@@ -124,10 +124,10 @@ struct eager_callback_cmd {
   std::string final_out = "";
 
   template <class F> void parse(F f) {
-    auto cb = [this](auto &&data, const auto &, const args::argument &) {
+    auto cb = [this](auto &&data, const auto &, const wahl::argument &) {
       final_out = std::to_string(data);
     };
-    f(count, "--count", "-C", args::eager_callback(cb));
+    f(count, "--count", "-C", wahl::eager_callback(cb));
     f(name, "--name", "-N");
   }
 
@@ -141,14 +141,14 @@ TEST_CASE("eager command callbacks") {
   REQUIRE_EQ(cmd.final_out, "");
 
   SUBCASE("options after the eager callback are not evaluated") {
-    args::parse(cmd, {"--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "");
     CHECK_EQ(cmd.final_out, "5");
   }
 
   SUBCASE("options up until the eager callback are evaluated") {
-    args::parse(cmd, {"--name", "hello", "--count", "5"});
+    wahl::parse(cmd, {"--name", "hello", "--count", "5"});
     CHECK_EQ(cmd.count, 5);
     CHECK_EQ(cmd.name, "hello");
     CHECK_EQ(cmd.final_out, "5");
@@ -161,7 +161,7 @@ struct action_null_cmd {
   std::string final_out = "";
 
   template <class F> void parse(F f) {
-    f(nullptr, "--out", "-O", args::action([this] { final_out = "out"; }));
+    f(nullptr, "--out", "-O", wahl::action([this] { final_out = "out"; }));
     f(count, "--count", "-C");
     f(name, "--name", "-N");
   }
@@ -176,7 +176,7 @@ TEST_CASE("command actions") {
   REQUIRE_EQ(cmd.final_out, "");
 
   SUBCASE("actions are eager callbacks without a parameter") {
-    args::parse(cmd, {"--out", "--count", "5", "--name", "hello"});
+    wahl::parse(cmd, {"--out", "--count", "5", "--name", "hello"});
     CHECK_EQ(cmd.count, 0);
     CHECK_EQ(cmd.name, "");
     CHECK_EQ(cmd.final_out, "out");

--- a/tests/source/count.cpp
+++ b/tests/source/count.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 #include <doctest/doctest.h>
 
 struct count_cmd {
@@ -8,9 +8,9 @@ struct count_cmd {
   bool flag = false;
 
   template <class F> void parse(F f) {
-    f(verbose, "-v", "--verbose", args::count());
-    f(verbose, "-q", "--quiet", args::set(0));
-    f(flag, "-f", "--flag", args::set(true));
+    f(verbose, "-v", "--verbose", wahl::count());
+    f(verbose, "-q", "--quiet", wahl::set(0));
+    f(flag, "-f", "--flag", wahl::set(true));
   }
 
   void run() {}
@@ -22,79 +22,79 @@ TEST_CASE("count command") {
   REQUIRE_FALSE(cmd.flag);
 
   SUBCASE("long options specified once") {
-    args::parse(cmd, {"--verbose", "--flag"});
+    wahl::parse(cmd, {"--verbose", "--flag"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options specified once") {
-    args::parse(cmd, {"-v", "-f"});
+    wahl::parse(cmd, {"-v", "-f"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short and long options mixes (1)") {
-    args::parse(cmd, {"--verbose", "-f"});
+    wahl::parse(cmd, {"--verbose", "-f"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short and long options mixes (2)") {
-    args::parse(cmd, {"-v", "--flag"});
+    wahl::parse(cmd, {"-v", "--flag"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options repeated twice without space") {
-    args::parse(cmd, {"-vv", "--flag"});
+    wahl::parse(cmd, {"-vv", "--flag"});
     CHECK_EQ(cmd.verbose, 2);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options repeated thrice without space") {
-    args::parse(cmd, {"-vvv", "--flag"});
+    wahl::parse(cmd, {"-vvv", "--flag"});
     CHECK_EQ(cmd.verbose, 3);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options and flags interleaved (1)") {
-    args::parse(cmd, {"-vf"});
+    wahl::parse(cmd, {"-vf"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options and flags interleaved (2)") {
-    args::parse(cmd, {"-fv"});
+    wahl::parse(cmd, {"-fv"});
     CHECK_EQ(cmd.verbose, 1);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options and flags interleaved (3)") {
-    args::parse(cmd, {"-vfv"});
+    wahl::parse(cmd, {"-vfv"});
     CHECK_EQ(cmd.verbose, 2);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short options and flags interleaved (4)") {
-    args::parse(cmd, {"-vvf"});
+    wahl::parse(cmd, {"-vvf"});
     CHECK_EQ(cmd.verbose, 2);
     CHECK(cmd.flag);
   }
 
   SUBCASE("short option and long option") {
-    args::parse(cmd, {"-v", "--verbose"});
+    wahl::parse(cmd, {"-v", "--verbose"});
     CHECK_EQ(cmd.verbose, 2);
     CHECK_FALSE(cmd.flag);
   }
 
   SUBCASE("repeated short option and long option") {
-    args::parse(cmd, {"-vv", "--verbose"});
+    wahl::parse(cmd, {"-vv", "--verbose"});
     CHECK_EQ(cmd.verbose, 3);
     CHECK_FALSE(cmd.flag);
   }
 
   SUBCASE("set callback sets a fixed value") {
-    args::parse(cmd, {"--flag", "-q"});
+    wahl::parse(cmd, {"--flag", "-q"});
     CHECK_EQ(cmd.verbose, 0);
     CHECK(cmd.flag);
   }

--- a/tests/source/group.cpp
+++ b/tests/source/group.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSL-1.0
 
-#include <args/args.hpp>
+#include <wahl/wahl.hpp>
 #include <doctest/doctest.h>
 
-struct cli : args::group<cli> {
+struct cli : wahl::group<cli> {
   std::string name = "";
 };
 
@@ -30,17 +30,17 @@ TEST_CASE("command groups") {
   REQUIRE_EQ(cmd.name, "");
 
   SUBCASE("command with automatic name") {
-    args::parse(cmd, {"init"});
+    wahl::parse(cmd, {"init"});
     CHECK_EQ(cmd.name, "init");
   }
 
   SUBCASE("command with manual name") {
-    args::parse(cmd, {"run"});
+    wahl::parse(cmd, {"run"});
     CHECK_EQ(cmd.name, "run");
   }
 
   SUBCASE("command with automatic name with trailing underscore") {
-    args::parse(cmd, {"delete"});
+    wahl::parse(cmd, {"delete"});
     CHECK_EQ(cmd.name, "delete");
   }
 }


### PR DESCRIPTION
I've chosen to go with wahl, a possible german translation for option. It's short enough to be directly used as a namespace and I was unable to find any other argument parser library with that name.